### PR TITLE
Add output validators, retries config, and Ollama compat fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,8 @@ OLLAMA_BASE_URL=http://localhost:11434/v1
 # ANTHROPIC_API_KEY=
 # GOOGLE_API_KEY=
 
+# Agent output validation retries (how many times to retry if LLM output fails schema validation)
+AGENT_RETRIES=3
+
 # Search / tools
 TAVILY_API_KEY=

--- a/app/agents/analyst.py
+++ b/app/agents/analyst.py
@@ -1,9 +1,9 @@
 """Data Analyst Agent: market sizing and competitive landscape."""
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext
 
 from app.context import ResearchContext
-from app.llm import get_model
+from app.llm import get_model, get_retries
 from app.schema import AnalystFindings
 from app.tools import deep_scrape, tavily_search
 
@@ -13,6 +13,7 @@ analyst_agent = Agent(
     model,
     deps_type=ResearchContext,
     output_type=AnalystFindings,
+    retries=get_retries(),
     instructions=(
         "You are a Data Analyst specialist. Perform market sizing and competitive landscape mapping. "
         "Use tavily_search for broad market data and deep_scrape for specific report pages. "
@@ -22,15 +23,32 @@ analyst_agent = Agent(
 )
 
 
+@analyst_agent.output_validator
+async def validate_analyst_output(
+    ctx: RunContext[ResearchContext], output: AnalystFindings
+) -> AnalystFindings:
+    """Only reject if the output is completely empty — no data at all."""
+    has_anything = (
+        output.market_sizes
+        or output.competitive_landscape
+        or output.summary
+    )
+    if not has_anything:
+        raise ModelRetry(
+            "Your output is completely empty. Populate at least one of: "
+            "market_sizes, competitive_landscape, or summary with data from your research."
+        )
+    return output
+
+
 @analyst_agent.tool
 async def tavily_search_tool(
     ctx: RunContext[ResearchContext],
     query: str,
     max_results: int = 5,
-    search_depth: str = "basic",
 ) -> str:
     """Broad web search for market data and competitor information."""
-    return await tavily_search(ctx, query, max_results=max_results, search_depth=search_depth)
+    return await tavily_search(ctx, query, max_results=max_results)
 
 
 @analyst_agent.tool

--- a/app/agents/lead.py
+++ b/app/agents/lead.py
@@ -6,7 +6,7 @@ from app.agents.analyst import analyst_agent
 from app.agents.reporter import reporter_agent
 from app.agents.researcher import researcher_agent
 from app.context import ResearchContext
-from app.llm import get_model
+from app.llm import get_model, get_retries
 from app.schema import AnalystFindings, MarketAccessFindings, MarketReport
 
 model = get_model()
@@ -16,6 +16,7 @@ lead_agent = Agent(
     model,
     deps_type=ResearchContext,
     output_type=MarketReport,
+    retries=get_retries(),
     instructions=(
         "You are the Lead Researcher. You receive a pharma market research query. "
         "Plan the research: (1) Use run_market_access_research to get regulatory, clinical trial, "

--- a/app/agents/reporter.py
+++ b/app/agents/reporter.py
@@ -1,9 +1,9 @@
 """Reporter Agent: synthesize findings into a publication-ready Markdown report."""
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, ModelRetry, RunContext
 
 from app.context import ResearchContext
-from app.llm import get_model
+from app.llm import get_model, get_retries
 from app.schema import AnalystFindings, MarketAccessFindings, MarketReport
 
 model = get_model()
@@ -12,6 +12,7 @@ reporter_agent = Agent(
     model,
     deps_type=ResearchContext,
     output_type=MarketReport,
+    retries=get_retries(),
     instructions=(
         "You are a Reporter. You receive structured findings from Market Access and Data Analyst agents. "
         "Synthesize them into a single publication-ready Markdown report. "
@@ -20,3 +21,16 @@ reporter_agent = Agent(
         "Write clearly for a pharma/biotech audience."
     ),
 )
+
+
+@reporter_agent.output_validator
+async def validate_reporter_output(
+    ctx: RunContext[ResearchContext], output: MarketReport
+) -> MarketReport:
+    """Only reject if the report is a skeleton — title and summary must exist."""
+    if not output.title or not output.executive_summary:
+        raise ModelRetry(
+            "Your report is missing essentials. Both 'title' and 'executive_summary' "
+            "must contain meaningful text. Synthesize the research findings."
+        )
+    return output

--- a/app/llm.py
+++ b/app/llm.py
@@ -1,10 +1,40 @@
 """Configurable LLM layer: Ollama by default, extensible to OpenAI/Google/Anthropic."""
 
 import os
+from collections.abc import Sequence
 from typing import Any
 
+from openai.types import chat
+from pydantic_ai.messages import ModelMessage
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.ollama import OllamaProvider
+
+
+class OllamaChatModel(OpenAIChatModel):
+    """Workarounds for Ollama's OpenAI-compatible API quirks.
+
+    Two known issues:
+    1. content: null on tool-call-only assistant turns → 400 "invalid content type: <nil>"
+    2. Literal newlines in content strings → 500 "invalid character '\\n' in string literal"
+       (Ollama's Go JSON parser is stricter than Python's — it trips on content that
+       the openai SDK serializes correctly but Ollama re-parses badly on its end.)
+    """
+
+    async def _map_messages(
+        self,
+        messages: Sequence[ModelMessage],
+        model_request_parameters: Any,
+    ) -> list[chat.ChatCompletionMessageParam]:
+        result = await super()._map_messages(messages, model_request_parameters)
+        for msg in result:
+            # Fix null content on assistant messages (issue 1)
+            if msg.get("content") is None and msg.get("role") == "assistant":
+                msg["content"] = ""
+            # Sanitize content strings for Ollama's picky parser (issue 2)
+            content = msg.get("content")
+            if isinstance(content, str):
+                msg["content"] = content.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+        return result
 
 
 def get_model() -> Any:
@@ -24,7 +54,7 @@ def get_model() -> Any:
 
     if provider == "ollama":
         base_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
-        return OpenAIChatModel(
+        return OllamaChatModel(
             model_name,
             provider=OllamaProvider(base_url=base_url),
         )
@@ -60,7 +90,12 @@ def get_model() -> Any:
 
     # Default: Ollama
     base_url = os.environ.get("OLLAMA_BASE_URL") or "http://localhost:11434/v1"
-    return OpenAIChatModel(
+    return OllamaChatModel(
         model_name,
         provider=OllamaProvider(base_url=base_url),
     )
+
+
+def get_retries() -> int:
+    """Return the configured agent output validation retry count."""
+    return int(os.environ.get("AGENT_RETRIES", "3"))

--- a/app/tools/tavily_tool.py
+++ b/app/tools/tavily_tool.py
@@ -40,6 +40,11 @@ async def tavily_search(
     if not api_key.strip():
         return "Tavily API key not set. Set TAVILY_API_KEY in environment and pass it via ResearchContext."
 
+    # LLMs love to hallucinate search_depth values like "deep" or "thorough"
+    valid_depths = {"basic", "advanced"}
+    if search_depth not in valid_depths:
+        search_depth = "basic"
+
     try:
         ctx.deps.add_event("tool_call", "Tavily", f"Searching: {query}")
         client = AsyncTavilyClient(api_key=api_key)


### PR DESCRIPTION
## Summary

- **Output validators** on Researcher, Analyst, and Reporter agents catch completely empty structured outputs and re-prompt the LLM with actionable `ModelRetry` feedback — preventing hollow reports from reaching the user
- **Configurable retries** via `AGENT_RETRIES` env var (default 3) replaces PydanticAI's default of 1, giving smaller local models more attempts to produce valid output
- **`OllamaChatModel`** subclass in `app/llm.py` patches two known Ollama OpenAI-compat API bugs:
  - `content: null` on tool-call-only assistant turns → 400 `"invalid content type: <nil>"`
  - Literal newlines in content strings → 500 `"invalid character '\n' in string literal"`
- **Tavily `search_depth` hardened** — validated server-side with fallback to `"basic"`, and removed from agent tool signatures so LLMs can't hallucinate invalid values

## Files changed

| File | What changed |
|------|-------------|
| `app/llm.py` | `OllamaChatModel` subclass + `get_retries()` helper |
| `app/agents/researcher.py` | Output validator, retries wiring, removed `search_depth` param |
| `app/agents/analyst.py` | Output validator, retries wiring, removed `search_depth` param |
| `app/agents/reporter.py` | Output validator, retries wiring |
| `app/agents/lead.py` | Retries wiring |
| `app/tools/tavily_tool.py` | `search_depth` validation with fallback |
| `.env.example` | Added `AGENT_RETRIES=3` |

## Test plan

- [ ] Run `uv run streamlit run app/ui.py` with Ollama backend — verify no 400/500 errors from null content or newlines
- [ ] Trigger an empty output (e.g. short timeout or weak model) — confirm retry feedback appears in usage stats
- [ ] Verify Tavily searches work with default depth when model would have sent invalid depth
- [ ] Test with `AGENT_RETRIES=1` to confirm env var is respected