### PR TITLE
feat(frontend): Bloomberg-terminal dark UI redesign (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Redesigned the app with a dark Bloomberg-terminal aesthetic: new landing page with animated swarm graph, dense sessions table with status filter chips, and a dedicated query entry page.
+- New `/query` route accepts a question, starts a research run, and navigates directly to the live run view — no extra clicks required.
+- Added `queued` and `paused` as valid session statuses throughout the UI.
 - Comprehensive offline test harness for the agent pipeline, covering per-agent isolation, full lead orchestration, retry-route checkpoint states, and per-stage retry behavior (17 new tests).
 
 ### Fixed

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -46,88 +46,82 @@
 }
 
 :root {
-  --background: oklch(0.975 0.006 85);
-  --foreground: oklch(0.17 0.02 255);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.17 0.02 255);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.17 0.02 255);
-  --primary: oklch(0.48 0.18 265);
-  --primary-foreground: oklch(0.99 0 0);
-  --secondary: oklch(0.94 0.005 85);
-  --secondary-foreground: oklch(0.17 0.02 255);
-  --muted: oklch(0.94 0.005 85);
-  --muted-foreground: oklch(0.55 0.01 255);
-  --accent: oklch(0.94 0.005 85);
-  --accent-foreground: oklch(0.17 0.02 255);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.91 0.006 85);
-  --input: oklch(0.91 0.006 85);
-  --ring: oklch(0.48 0.18 265);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --status-running-bg:  oklch(0.97 0.03 80);
-  --status-running-fg:  oklch(0.50 0.14 70);
-  --status-complete-bg: oklch(0.96 0.04 150);
-  --status-complete-fg: oklch(0.42 0.13 152);
-  --status-error-bg:    oklch(0.97 0.03 20);
-  --status-error-fg:    oklch(0.52 0.19 25);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.975 0.006 85);
-  --sidebar-foreground: oklch(0.17 0.02 255);
-  --sidebar-primary: oklch(0.48 0.18 265);
-  --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.94 0.005 85);
-  --sidebar-accent-foreground: oklch(0.17 0.02 255);
-  --sidebar-border: oklch(0.91 0.006 85);
-  --sidebar-ring: oklch(0.48 0.18 265);
-}
+  /* Bloomberg dark palette */
+  --bg:        oklch(0.13 0.025 250);
+  --surface:   oklch(0.17 0.025 248);
+  --surface-2: oklch(0.21 0.025 248);
+  --border:    oklch(0.28 0.020 248);
+  --text-hi:   oklch(0.96 0.005 248);
+  --text-md:   oklch(0.74 0.012 248);
+  --text-lo:   oklch(0.52 0.018 248);
+  --amber:     oklch(0.78 0.15  70);
+  --cyan:      oklch(0.80 0.13 200);
+  --green:     oklch(0.78 0.16 145);
+  --red:       oklch(0.68 0.22  25);
+  --violet:    oklch(0.72 0.16 295);
 
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* shadcn/Tailwind alias tokens — must keep resolving */
+  --background:         var(--bg);
+  --foreground:         var(--text-hi);
+  --card:               var(--surface);
+  --card-foreground:    var(--text-hi);
+  --popover:            var(--surface);
+  --popover-foreground: var(--text-hi);
+  --primary:            var(--amber);
+  --primary-foreground: oklch(0.10 0.02 70);
+  --secondary:          var(--surface-2);
+  --secondary-foreground: var(--text-hi);
+  --muted:              var(--surface-2);
+  --muted-foreground:   var(--text-md);
+  --accent:             var(--surface-2);
+  --accent-foreground:  var(--text-hi);
+  --destructive:        var(--red);
+  --input:              var(--surface-2);
+  --ring:               var(--amber);
+  --chart-1:            var(--amber);
+  --chart-2:            var(--cyan);
+  --chart-3:            var(--green);
+  --chart-4:            var(--violet);
+  --chart-5:            var(--red);
+  --radius: 0.125rem;
+
+  /* Status pip tokens — all 5 states */
+  --status-running-bg:   oklch(0.20 0.05 200);
+  --status-running-fg:   var(--cyan);
+  --status-complete-bg:  oklch(0.18 0.05 145);
+  --status-complete-fg:  var(--green);
+  --status-error-bg:     oklch(0.18 0.05  25);
+  --status-error-fg:     var(--red);
+  --status-queued-bg:    oklch(0.18 0.02 248);
+  --status-queued-fg:    var(--text-md);
+  --status-paused-bg:    oklch(0.20 0.05  70);
+  --status-paused-fg:    var(--amber);
+
+  /* Sidebar tokens */
+  --sidebar:             var(--surface);
+  --sidebar-foreground:  var(--text-hi);
+  --sidebar-primary:     var(--amber);
+  --sidebar-primary-foreground: oklch(0.10 0.02 70);
+  --sidebar-accent:      var(--surface-2);
+  --sidebar-accent-foreground: var(--text-hi);
+  --sidebar-border:      var(--border);
+  --sidebar-ring:        var(--amber);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
-  body {
-    @apply bg-background text-foreground;
-  }
   html {
     font-family: var(--font-sans);
+  }
+  body {
+    background: var(--bg);
+    color: var(--text-hi);
+  }
+
+  @keyframes buzz-pulse {
+    0%, 100% { opacity: 0.5; }
+    50% { opacity: 1; }
   }
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { Plus_Jakarta_Sans, Geist_Mono, Lora } from "next/font/google";
-import Link from "next/link";
+import { IBM_Plex_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
-const jakarta = Plus_Jakarta_Sans({
+const ibmPlexSans = IBM_Plex_Sans({
   variable: "--font-sans",
   subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
 });
 
-const mono = Geist_Mono({
+const jetbrainsMono = JetBrains_Mono({
   variable: "--font-mono",
   subsets: ["latin"],
-});
-
-const lora = Lora({
-  variable: "--font-serif",
-  subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
@@ -29,37 +25,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body
-        className={`${jakarta.variable} ${mono.variable} ${lora.variable} antialiased min-h-screen bg-background`}
+        className={`${ibmPlexSans.variable} ${jetbrainsMono.variable} antialiased min-h-screen`}
+        style={{ background: "var(--bg)", color: "var(--text-hi)" }}
       >
-        <nav className="border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 sticky top-0 z-50">
-          <div className="max-w-5xl mx-auto px-4 flex h-12 items-center gap-6">
-            <Link href="/" className="flex items-center gap-2">
-              <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center">
-                <span className="text-primary-foreground text-[10px] font-bold">Bz</span>
-              </div>
-              <span className="font-semibold text-sm tracking-tight">Buzz HC</span>
-            </Link>
-            <div className="flex items-center gap-4">
-              <Link
-                href="/run"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Research
-              </Link>
-              <Link
-                href="/sessions"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                History
-              </Link>
-            </div>
-          </div>
-        </nav>
-        <div className="max-w-5xl mx-auto px-4 py-8">
-          {children}
-        </div>
+        {children}
       </body>
     </html>
   );

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,181 +1,236 @@
 "use client";
 
-import Link from "next/link";
-import { Search, BarChart2, FileText, ArrowRight } from "lucide-react";
-import { motion } from "framer-motion";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { TopNav } from "@/components/buzz/TopNav";
+import { SwarmGraph } from "@/components/buzz/SwarmGraph";
+import { StatusDot } from "@/components/buzz/StatusDot";
+import { SectionLabel } from "@/components/buzz/SectionLabel";
+import { StatusChip } from "@/components/buzz/StatusChip";
 
-function HeroPreview() {
-  return (
-    <div className="bg-card border border-border/50 rounded-2xl shadow-sm p-5 h-full">
-      <div className="space-y-3">
-        <p className="font-[family-name:var(--font-serif)] text-sm font-semibold leading-snug">
-          GLP-1 Agonist Market Access Report 2030
-        </p>
-        <div className="border-l-2 border-primary/40 pl-2">
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            The GLP-1 agonist market is projected to exceed $130B by 2030, driven by obesity and T2D approvals…
-          </p>
-        </div>
-        <div className="space-y-1.5 pt-1">
-          <div className="bg-muted rounded h-2 w-full" />
-          <div className="bg-muted rounded h-2 w-5/6" />
-          <div className="bg-muted rounded h-2 w-4/5" />
-          <div className="bg-muted rounded h-2 w-full" />
-        </div>
-        <p className="text-[10px] uppercase tracking-wider text-primary/60 mt-3">
-          Competitive Landscape
-        </p>
-        <div className="space-y-1.5">
-          <div className="bg-muted rounded h-2 w-full" />
-          <div className="bg-muted rounded h-2 w-3/4" />
-          <div className="bg-muted rounded h-2 w-5/6" />
-        </div>
-        <p className="text-[10px] text-muted-foreground/50 pt-1">
-          Sources: FDA, EMA, ClinicalTrials.gov, Bloomberg Health
-        </p>
-      </div>
-    </div>
-  );
-}
+const SUGGESTIONS = [
+  "Map market access for GLP-1 agonists in EU5 through 2030",
+  "Competitive landscape for CAR-T therapies vs. BiTE antibodies",
+  "NICE HTA outcomes for rare disease gene therapies 2022–2025",
+];
 
-const featureCards = [
-  {
-    icon: Search,
-    title: "Market Access Research",
-    description: "Regulatory snapshots, clinical trial summaries, and reimbursement landscape analysis.",
-    colSpan: "col-span-1",
-  },
-  {
-    icon: BarChart2,
-    title: "Data Analysis",
-    description: "Market sizing estimates and competitive landscape mapping from live sources.",
-    colSpan: "col-span-1",
-  },
-  {
-    icon: FileText,
-    title: "Publication-Ready Reports",
-    description: "Structured markdown reports with PDF export, styled for pharma stakeholders.",
-    colSpan: "col-span-1",
-  },
+const LIVE_LOG = [
+  { t: "12:42:01", agent: "lead",     c: "var(--amber)",  msg: "planning · 6 subtasks queued" },
+  { t: "12:42:04", agent: "market",   c: "var(--cyan)",   msg: "GET clinicaltrials.gov · 47 trials" },
+  { t: "12:42:09", agent: "analyst",  c: "var(--violet)", msg: "reading IQVIA · TAM frame ready" },
+  { t: "12:42:14", agent: "market",   c: "var(--cyan)",   msg: "FDA orange book · 12 NDAs" },
+  { t: "12:42:18", agent: "lead",     c: "var(--amber)",  msg: "handoff → reporter · 18,402 tok", pulse: true },
+];
+
+const FEATURES = [
+  { l: "01", t: "Regulatory snapshots",     d: "FDA, EMA, PMDA filings · IND status · orange book mapping." },
+  { l: "02", t: "Clinical trial synthesis", d: "ClinicalTrials.gov · arm-by-arm analysis · primary endpoints." },
+  { l: "03", t: "Market sizing",            d: "TAM/SAM · CAGR · payer mix · published-source triangulation." },
+  { l: "04", t: "Structured dossier",       d: "Pydantic-validated markdown · PDF export · footnoted citations." },
+];
+
+const STATS = [
+  { l: "Avg run", v: "4:18", s: "min:sec" },
+  { l: "Sources", v: "2.4M", s: "indexed" },
+  { l: "Therapies", v: "1,847", s: "tracked" },
+  { l: "Accuracy", v: "94.2%", s: "vs analyst" },
 ];
 
 export default function Home() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  const onSubmit = () => {
+    if (query.trim()) {
+      router.push("/query?q=" + encodeURIComponent(query));
+    } else {
+      router.push("/query");
+    }
+  };
+
   return (
-    <div className="space-y-20 py-12">
-      {/* Hero */}
-      <div className="text-center space-y-6 max-w-2xl mx-auto">
-        <div className="inline-flex items-center gap-2 bg-primary/8 text-primary text-xs font-medium px-3 py-1 rounded-full border border-primary/20">
-          Multi-agent AI pipeline
+    <div style={{
+      background: "var(--bg)", color: "var(--text-hi)",
+      fontFamily: "var(--font-sans)",
+      display: "flex", flexDirection: "column", minHeight: "100vh",
+    }}>
+      <TopNav />
+
+      {/* Status strip */}
+      <div style={{
+        display: "flex", alignItems: "center",
+        padding: "0 16px", height: 28,
+        borderBottom: "1px solid var(--border)",
+        fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)",
+        gap: 18, flexShrink: 0,
+      }}>
+        <span style={{ color: "var(--amber)" }}>● LIVE</span>
+        <span>BUZZ HC v1.4.2</span>
+        <span>4 AGENTS ONLINE</span>
+        <span>3 RUNS IN-FLIGHT</span>
+        <span style={{ marginLeft: "auto" }}>WED · 24 MAY · 12:42:18 UTC</span>
+      </div>
+
+      {/* Hero — 2 columns */}
+      <div style={{
+        display: "grid", gridTemplateColumns: "minmax(0,1fr) 560px",
+        flex: 1, minHeight: 0,
+      }}>
+        {/* Left */}
+        <div style={{
+          padding: "56px 56px 40px",
+          display: "flex", flexDirection: "column",
+          justifyContent: "center",
+          borderRight: "1px solid var(--border)",
+          gap: 28,
+        }}>
+          <SectionLabel>Multi-agent pharma intelligence</SectionLabel>
+
+          <h1 style={{
+            fontSize: 64, lineHeight: 0.98, fontWeight: 600,
+            letterSpacing: "-0.025em", margin: 0,
+          }}>
+            Publication-grade<br />
+            market research,<br />
+            <span style={{ color: "var(--amber)" }}>fielded by a swarm.</span>
+          </h1>
+
+          <p style={{
+            fontSize: 15, lineHeight: 1.55, color: "var(--text-md)",
+            margin: 0, maxWidth: 460,
+          }}>
+            Four specialized agents — orchestrator, market access, analyst, reporter — work in parallel
+            against FDA, EMA, ClinicalTrials.gov, and live web sources to produce a structured pharma dossier in minutes.
+          </p>
+
+          {/* Query box */}
+          <div
+            style={{
+              display: "flex", alignItems: "center",
+              border: "1px solid var(--border)", borderRadius: 2,
+              background: "var(--surface)",
+            }}
+            onFocus={(e) => e.currentTarget.style.borderColor = "var(--amber)"}
+            onBlur={(e) => e.currentTarget.style.borderColor = "var(--border)"}
+          >
+            <span style={{ padding: "0 12px", color: "var(--amber)", fontFamily: "var(--font-mono)", fontSize: 13 }}>›</span>
+            <input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              onKeyDown={e => { if (e.key === "Enter") onSubmit(); }}
+              placeholder="Ask the swarm anything pharma…"
+              style={{
+                flex: 1, padding: "14px 0",
+                background: "transparent", border: "none", outline: "none",
+                color: "var(--text-hi)", fontFamily: "var(--font-sans)", fontSize: 14,
+              }}
+            />
+            <button
+              onClick={onSubmit}
+              style={{
+                background: "var(--amber)", color: "#0a0d14",
+                border: "none", padding: "12px 18px",
+                fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 600,
+                letterSpacing: "0.14em", textTransform: "uppercase", cursor: "pointer",
+                display: "inline-flex", alignItems: "center", gap: 6,
+              }}
+            >
+              Run swarm ↵
+            </button>
+          </div>
+
+          {/* Suggestions */}
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: -12 }}>
+            {SUGGESTIONS.map(s => (
+              <button
+                key={s}
+                onClick={() => setQuery(s)}
+                style={{
+                  padding: "4px 9px", border: "1px solid var(--border)",
+                  background: "transparent", color: "var(--text-md)",
+                  fontFamily: "var(--font-mono)", fontSize: 10, cursor: "pointer",
+                  borderRadius: 2, letterSpacing: "0.04em",
+                }}
+              >
+                ↗ {s.length > 56 ? s.slice(0, 56) + "…" : s}
+              </button>
+            ))}
+          </div>
+
+          {/* Stats row */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "repeat(4, 1fr)",
+            marginTop: 16,
+            borderTop: "1px solid var(--border)",
+            borderBottom: "1px solid var(--border)",
+          }}>
+            {STATS.map((s, i) => (
+              <div key={i} style={{ padding: "14px 16px", borderRight: i < 3 ? "1px solid var(--border)" : "none" }}>
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)", letterSpacing: "0.16em", textTransform: "uppercase" }}>{s.l}</div>
+                <div style={{ fontSize: 22, fontWeight: 600, marginTop: 4, fontVariantNumeric: "tabular-nums" }}>{s.v}</div>
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)", marginTop: 2 }}>{s.s}</div>
+              </div>
+            ))}
+          </div>
         </div>
-        <h1 className="text-4xl font-bold tracking-tight">
-          Pharma Market Intelligence,{" "}
-          <span className="text-primary">in minutes</span>
-        </h1>
-        <p className="text-muted-foreground text-base leading-relaxed max-w-lg mx-auto">
-          A three-agent AI pipeline — Researcher, Analyst, Reporter — that delivers
-          structured market access and competitive landscape reports from live data sources.
-        </p>
-        <div className="flex gap-3 justify-center pt-2">
-          <Link
-            href="/run"
-            className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground px-6 h-10 text-sm font-medium transition-colors hover:bg-primary/90"
-          >
-            Start Research
-          </Link>
-          <Link
-            href="/sessions"
-            className="inline-flex items-center justify-center rounded-full border border-border bg-card px-6 h-10 text-sm font-medium transition-colors hover:bg-muted"
-          >
-            View History
-          </Link>
+
+        {/* Right — swarm + log */}
+        <div style={{ display: "flex", flexDirection: "column", background: "var(--surface)" }}>
+          <div style={{
+            padding: "12px 16px", borderBottom: "1px solid var(--border)",
+            display: "flex", alignItems: "center", gap: 12,
+          }}>
+            <SectionLabel>Swarm visualization</SectionLabel>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)", marginLeft: "auto" }}>
+              DEMO
+            </span>
+            <StatusChip status="running" label="Live" />
+          </div>
+
+          <div style={{ padding: "20px 16px", display: "flex", justifyContent: "center" }}>
+            <SwarmGraph width={520} height={360} animate />
+          </div>
+
+          <div style={{
+            borderTop: "1px solid var(--border)",
+            padding: "12px 16px", flex: 1,
+            display: "flex", flexDirection: "column", gap: 10,
+            background: "var(--bg)",
+          }}>
+            <SectionLabel>Live stream</SectionLabel>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)", lineHeight: 1.7 }}>
+              {LIVE_LOG.map((l, i) => (
+                <div key={i} style={{ display: "flex", gap: 12, alignItems: "center", opacity: 1 - i * 0.05 }}>
+                  <span style={{ color: "var(--text-lo)" }}>{l.t}</span>
+                  <span style={{ color: l.c, letterSpacing: "0.14em", fontSize: 10, fontWeight: 600, width: 70 }}>{l.agent.toUpperCase()}</span>
+                  <span style={{ color: l.pulse ? "var(--amber)" : "var(--text-md)", flex: 1 }}>{l.msg}</span>
+                  {l.pulse && <StatusDot status="live" pulse />}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* Bento grid */}
-      <div className="grid grid-cols-3 gap-4 auto-rows-[minmax(180px,auto)]">
-        {/* HeroPreview — spans 2 cols, 2 rows */}
-        <motion.div
-          className="col-span-2 row-span-2"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0 }}
-          whileHover={{ scale: 1.015, y: -2 }}
-        >
-          <HeroPreview />
-        </motion.div>
-
-        {/* Feature 1 */}
-        <motion.div
-          className="col-span-1"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.1 }}
-          whileHover={{ scale: 1.015, y: -2 }}
-        >
-          <div className="bg-card border border-border/50 rounded-2xl shadow-sm p-5 h-full space-y-3">
-            <div className="w-9 h-9 rounded-lg bg-primary/10 text-primary flex items-center justify-center">
-              <Search className="w-5 h-5" />
+      {/* Feature strip */}
+      <div style={{
+        display: "grid", gridTemplateColumns: "repeat(4, 1fr)",
+        borderTop: "1px solid var(--border)", height: 132,
+      }}>
+        {FEATURES.map((f, i) => (
+          <div key={i} style={{
+            padding: "16px 20px",
+            borderRight: i < 3 ? "1px solid var(--border)" : "none",
+            display: "flex", flexDirection: "column", gap: 8,
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--amber)", letterSpacing: "0.14em" }}>{f.l}</span>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)" }}>→</span>
             </div>
-            <h3 className="font-semibold text-sm">{featureCards[0].title}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{featureCards[0].description}</p>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>{f.t}</div>
+            <div style={{ fontSize: 12, color: "var(--text-md)", lineHeight: 1.5 }}>{f.d}</div>
           </div>
-        </motion.div>
-
-        {/* Feature 2 */}
-        <motion.div
-          className="col-span-1"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.15 }}
-          whileHover={{ scale: 1.015, y: -2 }}
-        >
-          <div className="bg-card border border-border/50 rounded-2xl shadow-sm p-5 h-full space-y-3">
-            <div className="w-9 h-9 rounded-lg bg-primary/10 text-primary flex items-center justify-center">
-              <BarChart2 className="w-5 h-5" />
-            </div>
-            <h3 className="font-semibold text-sm">{featureCards[1].title}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{featureCards[1].description}</p>
-          </div>
-        </motion.div>
-
-        {/* Feature 3 */}
-        <motion.div
-          className="col-span-1"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.2 }}
-          whileHover={{ scale: 1.015, y: -2 }}
-        >
-          <div className="bg-card border border-border/50 rounded-2xl shadow-sm p-5 h-full space-y-3">
-            <div className="w-9 h-9 rounded-lg bg-primary/10 text-primary flex items-center justify-center">
-              <FileText className="w-5 h-5" />
-            </div>
-            <h3 className="font-semibold text-sm">{featureCards[2].title}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{featureCards[2].description}</p>
-          </div>
-        </motion.div>
-
-        {/* CTA card */}
-        <motion.div
-          className="col-span-2"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, delay: 0.25 }}
-          whileHover={{ scale: 1.015, y: -2 }}
-        >
-          <Link href="/run" className="block h-full">
-            <div className="bg-gradient-to-br from-primary/8 to-primary/18 border border-primary/20 rounded-2xl shadow-sm p-5 h-full flex items-center justify-between gap-4">
-              <div className="space-y-1">
-                <p className="font-semibold text-sm">Ready to get started?</p>
-                <p className="text-sm text-muted-foreground">Run your first pharma research query in seconds.</p>
-              </div>
-              <div className="flex items-center gap-2 text-primary font-medium text-sm whitespace-nowrap">
-                Start Research
-                <ArrowRight className="w-4 h-4" />
-              </div>
-            </div>
-          </Link>
-        </motion.div>
+        ))}
       </div>
     </div>
   );

--- a/web/app/query/page.tsx
+++ b/web/app/query/page.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { Suspense, useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { TopNav } from "@/components/buzz/TopNav";
+import { SectionLabel } from "@/components/buzz/SectionLabel";
+import { Btn } from "@/components/buzz/Btn";
+import { startRun } from "@/lib/api";
+import Link from "next/link";
+
+const SUGGESTIONS = [
+  "Map market access for GLP-1 agonists in EU5 through 2030 — sizing, payers, key catalysts.",
+  "Competitive landscape for CAR-T therapies: BiTE antibodies vs. autologous vs. allogeneic.",
+  "NICE HTA outcomes for rare disease gene therapies approved 2022–2025.",
+  "FDA breakthrough designations in oncology: pipeline analysis and probability of approval.",
+];
+
+const PIPELINE_STAGES = [
+  { id: "plan",    label: "Orchestration plan",    desc: "LEAD" },
+  { id: "access",  label: "Market access research", desc: "MARKET" },
+  { id: "sizing",  label: "Market sizing",          desc: "ANALYST" },
+  { id: "comp",    label: "Competitive analysis",   desc: "ANALYST" },
+  { id: "synth",   label: "Synthesis & report",     desc: "REPORTER" },
+];
+
+const AGENTS = [
+  { id: "lead",     name: "LEAD",     role: "Orchestrator",        color: "var(--amber)"  },
+  { id: "market",   name: "MARKET",   role: "Regulatory + Access", color: "var(--cyan)"   },
+  { id: "analyst",  name: "ANALYST",  role: "Sizing + Comp",       color: "var(--violet)" },
+  { id: "reporter", name: "REPORTER", role: "Synthesis",           color: "var(--green)"  },
+];
+
+function QueryInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [query, setQuery] = useState(searchParams.get("q") ?? "");
+  const [depth, setDepth] = useState<"quick" | "standard" | "deep">("standard");
+  const [budget, setBudget] = useState(2.0);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const q = searchParams.get("q");
+    if (q) setQuery(q);
+  }, [searchParams]);
+
+  const runNow = async () => {
+    if (!query.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await startRun(query);
+      router.push("/run/" + result.session_id);
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  const depthOptions = [
+    { id: "quick",    l: "Quick",    desc: "~2 min · 30 sources · 1 agent" },
+    { id: "standard", l: "Standard", desc: "~5 min · 80 sources · 4 agents" },
+    { id: "deep",     l: "Deep",     desc: "~12 min · 200+ sources · re-verify" },
+  ] as const;
+
+  return (
+    <div style={{
+      background: "var(--bg)", color: "var(--text-hi)",
+      fontFamily: "var(--font-sans)",
+      display: "flex", flexDirection: "column", minHeight: "100vh",
+    }}>
+      <TopNav />
+
+      {/* Breadcrumb */}
+      <div style={{
+        padding: "10px 16px", borderBottom: "1px solid var(--border)",
+        fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)",
+        letterSpacing: "0.14em", textTransform: "uppercase",
+        background: "var(--surface)",
+        display: "flex", alignItems: "center", gap: 12,
+      }}>
+        <Link href="/" style={{ color: "var(--text-md)", textDecoration: "none" }}>Research</Link>
+        <span>›</span>
+        <span style={{ color: "var(--text-hi)" }}>New Query</span>
+        <span style={{ marginLeft: "auto", color: submitting ? "var(--amber)" : "var(--text-lo)" }}>
+          {submitting ? "▸ DISPATCHING SWARM…" : "READY · ⌘↵ TO RUN"}
+        </span>
+      </div>
+
+      {/* Main body */}
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "minmax(0, 1fr) 360px" }}>
+        {/* Left — composer */}
+        <div style={{ padding: "48px 64px", display: "flex", flexDirection: "column", gap: 28, maxWidth: 880 }}>
+          <div>
+            <SectionLabel>Compose · brief</SectionLabel>
+            <h1 style={{ fontSize: 42, fontWeight: 600, letterSpacing: "-0.02em", margin: "12px 0 6px 0" }}>
+              What should the swarm investigate?
+            </h1>
+            <p style={{ fontSize: 14, color: "var(--text-md)", margin: 0, maxWidth: 580, lineHeight: 1.55 }}>
+              The brief becomes the orchestrator&apos;s plan. Be specific about geography,
+              therapeutic area, and time horizon — the swarm uses these as constraints when scoping sources.
+            </p>
+          </div>
+
+          {/* Textarea */}
+          <div style={{ border: "1px solid var(--border)", borderRadius: 2, background: "var(--surface)", overflow: "hidden" }}>
+            <div style={{
+              padding: "10px 14px", borderBottom: "1px solid var(--border)",
+              display: "flex", alignItems: "center", gap: 10,
+            }}>
+              <span style={{ color: "var(--amber)", fontFamily: "var(--font-mono)", fontSize: 12 }}>›</span>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-md)", letterSpacing: "0.14em", textTransform: "uppercase" }}>
+                Brief
+              </span>
+              <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)" }}>
+                {query.length} / 2000
+              </span>
+            </div>
+            <textarea
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              onKeyDown={e => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) runNow(); }}
+              autoFocus
+              placeholder="e.g. Map market access for GLP-1 agonists in EU5 through 2030 — sizing, payers, key catalysts."
+              style={{
+                width: "100%", minHeight: 160, padding: "16px 18px",
+                background: "transparent", border: "none", outline: "none",
+                color: "var(--text-hi)", fontFamily: "var(--font-sans)", fontSize: 15, lineHeight: 1.55,
+                resize: "vertical", boxSizing: "border-box",
+              }}
+            />
+          </div>
+
+          {/* Suggestions */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <SectionLabel>Suggestions</SectionLabel>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              {SUGGESTIONS.map(s => (
+                <button key={s} onClick={() => setQuery(s)} style={{
+                  padding: "8px 12px", border: "1px solid var(--border)",
+                  background: "transparent", color: "var(--text-md)",
+                  fontFamily: "var(--font-sans)", fontSize: 12, cursor: "pointer",
+                  borderRadius: 2, textAlign: "left",
+                }}>↗ {s}</button>
+              ))}
+            </div>
+          </div>
+
+          {/* Depth + Budget */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+            <div style={{ border: "1px solid var(--border)", padding: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+              <SectionLabel>Depth</SectionLabel>
+              <div style={{ display: "flex", border: "1px solid var(--border)", borderRadius: 2, overflow: "hidden" }}>
+                {depthOptions.map((d, idx) => (
+                  <button key={d.id} onClick={() => setDepth(d.id)} style={{
+                    flex: 1, padding: "10px 8px",
+                    background: depth === d.id ? "var(--amber)" : "transparent",
+                    color: depth === d.id ? "#0a0d14" : "var(--text-md)",
+                    border: "none", cursor: "pointer",
+                    fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 600,
+                    letterSpacing: "0.12em", textTransform: "uppercase",
+                    borderRight: idx < 2 ? "1px solid var(--border)" : "none",
+                  }}>{d.l}</button>
+                ))}
+              </div>
+              <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)" }}>
+                {depthOptions.find(d => d.id === depth)?.desc}
+              </div>
+            </div>
+
+            <div style={{ border: "1px solid var(--border)", padding: 14, display: "flex", flexDirection: "column", gap: 10 }}>
+              <SectionLabel>Token budget</SectionLabel>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+                <span style={{ fontSize: 26, fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>${budget.toFixed(2)}</span>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)" }}>cap</span>
+              </div>
+              <input
+                type="range" min="0.5" max="5" step="0.5"
+                value={budget} onChange={e => setBudget(parseFloat(e.target.value))}
+                style={{ width: "100%", accentColor: "var(--amber)" }}
+              />
+              <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)" }}>
+                stop run if exceeded · est ${(budget * 0.6).toFixed(2)} for this brief
+              </div>
+            </div>
+          </div>
+
+          {/* CTA */}
+          <div style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 8 }}>
+            <Btn primary onClick={runNow} disabled={!query.trim() || submitting}>
+              {submitting ? "Dispatching…" : "Dispatch swarm ↵"}
+            </Btn>
+            <Link href="/" style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)", letterSpacing: "0.14em", textTransform: "uppercase", textDecoration: "none" }}>
+              ← Cancel
+            </Link>
+          </div>
+        </div>
+
+        {/* Right — plan preview */}
+        <div style={{ background: "var(--surface)", borderLeft: "1px solid var(--border)", display: "flex", flexDirection: "column" }}>
+          <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>
+            <SectionLabel>Plan preview · agent will refine</SectionLabel>
+          </div>
+
+          <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 14 }}>
+            <div style={{
+              fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)",
+              border: "1px solid var(--border)", padding: 12, lineHeight: 1.55,
+              background: "var(--bg)", borderRadius: 2,
+            }}>
+              {query
+                ? <span style={{ color: "var(--text-hi)" }}>{query}</span>
+                : <span style={{ color: "var(--text-lo)" }}>Brief preview will appear here…</span>}
+            </div>
+
+            <SectionLabel>Planned stages</SectionLabel>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {PIPELINE_STAGES.map((s, i) => (
+                <div key={s.id} style={{
+                  display: "flex", gap: 10, alignItems: "center",
+                  padding: "8px 0",
+                  borderTop: i === 0 ? "1px solid var(--border)" : "1px dashed var(--border)",
+                }}>
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)", width: 24 }}>{String(i + 1).padStart(2, "0")}</span>
+                  <span style={{ fontSize: 12, color: "var(--text-hi)", flex: 1 }}>{s.label}</span>
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-md)" }}>{s.desc}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ borderTop: "1px solid var(--border)", marginTop: "auto", padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}>
+            <SectionLabel>Agents on call</SectionLabel>
+            {AGENTS.map(a => (
+              <div key={a.id} style={{
+                display: "flex", alignItems: "center", gap: 10,
+                padding: "6px 0", borderBottom: "1px dashed var(--border)",
+              }}>
+                <span style={{ width: 8, height: 8, background: a.color, display: "inline-block" }} />
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: a.color, letterSpacing: "0.14em", fontWeight: 600, width: 70 }}>{a.name}</span>
+                <span style={{ fontSize: 11, color: "var(--text-md)" }}>{a.role}</span>
+                <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)" }}>READY</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function QueryPage() {
+  return (
+    <Suspense fallback={null}>
+      <QueryInner />
+    </Suspense>
+  );
+}

--- a/web/app/sessions/page.tsx
+++ b/web/app/sessions/page.tsx
@@ -1,162 +1,289 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { TopNav } from "@/components/buzz/TopNav";
+import { SectionLabel } from "@/components/buzz/SectionLabel";
+import { StatusDot } from "@/components/buzz/StatusDot";
+import { Btn } from "@/components/buzz/Btn";
 import { getSessions } from "@/lib/api";
 import type { SessionSummary, SessionStatus } from "@/lib/types";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { buttonVariants } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
-import { ChevronRight, FlaskConical } from "lucide-react";
+import Link from "next/link";
 
-function StatusBadge({ status }: { status: SessionStatus }) {
-  if (status === "running") return (
-    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-[var(--status-running-bg)] text-[var(--status-running-fg)]">
-      <span className="w-1.5 h-1.5 rounded-full bg-current animate-pulse" />
-      Running
-    </span>
-  );
-  if (status === "complete") return (
-    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-[var(--status-complete-bg)] text-[var(--status-complete-fg)]">
-      <span className="w-1.5 h-1.5 rounded-full bg-current" />
-      Complete
-    </span>
-  );
+const GRID = "94px 1fr 80px 110px 110px 110px 90px 100px 80px";
+
+const STATUS_COLOR: Record<SessionStatus, string> = {
+  running:  "var(--cyan)",
+  complete: "var(--green)",
+  error:    "var(--red)",
+  queued:   "var(--text-lo)",
+  paused:   "var(--amber)",
+};
+
+const STATUS_LABEL: Record<SessionStatus, string> = {
+  running:  "RUN",
+  complete: "DONE",
+  error:    "ERR",
+  queued:   "QUE",
+  paused:   "PSE",
+};
+
+function StatusCell({ status }: { status: SessionStatus }) {
+  const c = STATUS_COLOR[status] ?? "var(--text-lo)";
+  const label = STATUS_LABEL[status] ?? status.toUpperCase();
   return (
-    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-[var(--status-error-bg)] text-[var(--status-error-fg)]">
-      <span className="w-1.5 h-1.5 rounded-full bg-current" />
-      Error
-    </span>
+    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+      <StatusDot status={status} pulse={status === "running"} />
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: c, letterSpacing: "0.14em", fontWeight: 600 }}>{label}</span>
+    </div>
   );
 }
 
-function formatDate(ts: string): string {
+type FilterKey = "all" | SessionStatus;
+
+const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
+  { key: "all",      label: "All" },
+  { key: "running",  label: "Running" },
+  { key: "complete", label: "Complete" },
+  { key: "queued",   label: "Queued" },
+  { key: "error",    label: "Error" },
+];
+
+const STATS_CONFIG = [
+  { l: "Total runs",    v: "—", sub: "all-time" },
+  { l: "This week",     v: "—", sub: "—" },
+  { l: "Avg duration",  v: "—", sub: "min:sec p50" },
+  { l: "Tokens (24h)",  v: "—", sub: "ctx avg —" },
+  { l: "Cost (24h)",    v: "—", sub: "$— / run" },
+  { l: "Success rate",  v: "—", sub: "— errors / 30d" },
+];
+
+function fmtDate(iso: string) {
   try {
-    return new Date(ts).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return new Date(iso).toLocaleDateString("en-GB", { day: "2-digit", month: "short" });
   } catch {
-    return ts;
+    return "—";
   }
 }
 
 export default function SessionsPage() {
+  const router = useRouter();
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
-  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<FilterKey>("all");
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  async function load(q: string) {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await getSessions({ search: q, limit: 50 });
-      setSessions(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }
 
   useEffect(() => {
-    load("");
+    getSessions().then(data => {
+      setSessions(data);
+      setLoading(false);
+    }).catch(() => setLoading(false));
   }, []);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    load(search);
+  const counts: Record<FilterKey, number> = {
+    all:      sessions.length,
+    running:  sessions.filter(s => s.status === "running").length,
+    complete: sessions.filter(s => s.status === "complete").length,
+    queued:   sessions.filter(s => s.status === "queued").length,
+    error:    sessions.filter(s => s.status === "error").length,
+    paused:   sessions.filter(s => s.status === "paused").length,
+  };
+
+  const filtered = filter === "all" ? sessions : sessions.filter(s => s.status === filter);
+
+  const onRow = (s: SessionSummary) => {
+    if (s.status === "complete") {
+      router.push("/report/" + s.session_id);
+    } else {
+      router.push("/run/" + s.session_id);
+    }
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Research History</h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            All past research sessions, newest first.
-          </p>
+    <div style={{
+      background: "var(--bg)", color: "var(--text-hi)",
+      fontFamily: "var(--font-sans)",
+      display: "flex", flexDirection: "column", minHeight: "100vh",
+    }}>
+      <TopNav />
+
+      {/* Page header */}
+      <div style={{
+        padding: "28px 32px 20px",
+        borderBottom: "1px solid var(--border)",
+        display: "flex", alignItems: "flex-end", gap: 28,
+      }}>
+        <div style={{ flex: 1 }}>
+          <SectionLabel>History · all-time</SectionLabel>
+          <h1 style={{ fontSize: 38, fontWeight: 600, letterSpacing: "-0.02em", margin: "8px 0 0 0" }}>Sessions</h1>
         </div>
-        <Link href="/run" className={cn(buttonVariants(), "rounded-full")}>
-          + New Research
-        </Link>
+        <div style={{ display: "flex", gap: 8 }}>
+          <Btn>Export CSV</Btn>
+          <Link href="/query"><Btn primary>+ New Run</Btn></Link>
+        </div>
       </div>
 
-      <form onSubmit={handleSearch} className="max-w-md">
-        <div className="flex rounded-xl border border-input overflow-hidden">
-          <Input
-            type="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search queries…"
-            className="flex-1 border-0 rounded-none focus-visible:ring-0 focus-visible:ring-offset-0"
-          />
-          <Button type="submit" variant="secondary" className="rounded-none rounded-r-xl border-0 border-l border-input">
-            Search
-          </Button>
-        </div>
-      </form>
-
-      {loading && (
-        <div className="flex items-center justify-center py-16 text-muted-foreground text-sm">
-          Loading sessions…
-        </div>
-      )}
-
-      {error && (
-        <Card className="rounded-2xl">
-          <CardContent className="pt-6 text-sm text-destructive text-center">
-            {error}
-          </CardContent>
-        </Card>
-      )}
-
-      {!loading && !error && sessions.length === 0 && (
-        <Card className="rounded-2xl">
-          <CardContent className="pt-12 pb-12 text-center space-y-3">
-            <div className="flex justify-center">
-              <FlaskConical className="w-10 h-10 text-muted-foreground/40" />
-            </div>
-            <p className="font-medium text-sm">No research sessions yet</p>
-            <p className="text-xs text-muted-foreground">Run your first query to see results here.</p>
-            <Link href="/run" className={cn(buttonVariants({ variant: "outline", size: "sm" }), "rounded-full")}>
-              Start your first research run
-            </Link>
-          </CardContent>
-        </Card>
-      )}
-
-      {!loading && sessions.length > 0 && (
-        <Card className="rounded-2xl shadow-sm">
-          <div className="divide-y divide-border">
-            {sessions.map((s) => (
-              <Link
-                key={s.session_id}
-                href={`/sessions/${s.session_id}`}
-                className="flex items-center justify-between gap-4 px-5 py-4 hover:bg-muted/40 transition-colors group"
-              >
-                <div className="space-y-1 min-w-0">
-                  <p className="text-sm font-medium leading-snug line-clamp-2">
-                    {s.query}
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <StatusBadge status={s.status} />
-                    <span className="text-xs text-muted-foreground">
-                      {formatDate(s.timestamp)}
-                    </span>
-                  </div>
-                </div>
-                <ChevronRight className="w-4 h-4 text-muted-foreground/40 shrink-0 group-hover:text-muted-foreground transition-colors" />
-              </Link>
-            ))}
+      {/* Stats bar */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", borderBottom: "1px solid var(--border)" }}>
+        {STATS_CONFIG.map((s, i) => (
+          <div key={i} style={{
+            padding: "16px 20px",
+            borderRight: i < 5 ? "1px solid var(--border)" : "none",
+            display: "flex", flexDirection: "column", gap: 4,
+          }}>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)", letterSpacing: "0.16em", textTransform: "uppercase" }}>{s.l}</div>
+            <div style={{ fontSize: 24, fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{s.v}</div>
+            <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-md)" }}>{s.sub}</div>
           </div>
-        </Card>
-      )}
+        ))}
+      </div>
+
+      {/* Filters */}
+      <div style={{
+        padding: "14px 32px",
+        borderBottom: "1px solid var(--border)",
+        display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
+      }}>
+        <div style={{ display: "flex", gap: 6, flex: 1 }}>
+          {FILTER_OPTIONS.map(({ key, label }) => {
+            const active = filter === key;
+            const count = counts[key] ?? 0;
+            return (
+              <button
+                key={key}
+                onClick={() => setFilter(key)}
+                style={{
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                  padding: "5px 10px",
+                  background: active ? "var(--amber)" : "transparent",
+                  color: active ? "#0a0d14" : "var(--text-md)",
+                  border: active ? "1px solid var(--amber)" : "1px solid var(--border)",
+                  borderRadius: 2,
+                  fontFamily: "var(--font-mono)", fontSize: 10,
+                  letterSpacing: "0.12em", textTransform: "uppercase",
+                  cursor: "pointer",
+                }}
+              >
+                {label}
+                <span style={{ color: active ? "rgba(0,0,0,0.6)" : "var(--text-lo)", fontVariantNumeric: "tabular-nums" }}>{count}</span>
+              </button>
+            );
+          })}
+        </div>
+        <div style={{
+          display: "flex", alignItems: "center", gap: 8,
+          border: "1px solid var(--border)", padding: "4px 10px",
+          borderRadius: 2, minWidth: 280,
+        }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-lo)" }}>⌕</span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)" }}>Search queries, IDs, sources…</span>
+          <span style={{ marginLeft: "auto", fontFamily: "var(--font-mono)", fontSize: 10, padding: "1px 5px", border: "1px solid var(--border)", color: "var(--text-lo)", borderRadius: 2 }}>⌘K</span>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div style={{ flex: 1 }}>
+        {/* Header row */}
+        <div style={{
+          display: "grid", gridTemplateColumns: GRID,
+          padding: "10px 32px",
+          borderBottom: "1px solid var(--border)",
+          background: "var(--surface)",
+          fontFamily: "var(--font-mono)", fontSize: 9,
+          color: "var(--text-lo)", letterSpacing: "0.16em", textTransform: "uppercase",
+        }}>
+          <span>ID</span>
+          <span>Query</span>
+          <span>Status</span>
+          <span>Started</span>
+          <span>Duration</span>
+          <span style={{ textAlign: "right" }}>Tokens</span>
+          <span style={{ textAlign: "right" }}>Sources</span>
+          <span style={{ textAlign: "right" }}>Cost</span>
+          <span style={{ textAlign: "center" }}>Agents</span>
+        </div>
+
+        {loading && (
+          <div style={{ padding: "32px", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-lo)" }}>
+            Loading sessions…
+          </div>
+        )}
+
+        {!loading && filtered.length === 0 && (
+          <div style={{ padding: "32px", fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-lo)" }}>
+            No sessions found.
+          </div>
+        )}
+
+        {filtered.map((s, i) => (
+          <div
+            key={s.session_id}
+            onClick={() => onRow(s)}
+            style={{
+              display: "grid", gridTemplateColumns: GRID,
+              padding: "12px 32px",
+              borderBottom: i < filtered.length - 1 ? "1px solid var(--border)" : "none",
+              alignItems: "center", cursor: "pointer",
+              background:
+                s.status === "running" ? "rgba(34, 211, 238, 0.04)" :
+                s.status === "error"   ? "rgba(239, 68, 68, 0.04)"  :
+                "transparent",
+              transition: "background 0.12s",
+            }}
+            onMouseEnter={e => { e.currentTarget.style.background = "rgba(245, 158, 11, 0.05)"; }}
+            onMouseLeave={e => {
+              e.currentTarget.style.background =
+                s.status === "running" ? "rgba(34, 211, 238, 0.04)" :
+                s.status === "error"   ? "rgba(239, 68, 68, 0.04)"  :
+                "transparent";
+            }}
+          >
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--amber)", fontWeight: 600 }}>
+              {s.session_id.slice(0, 8).toUpperCase()}
+            </span>
+
+            <div style={{ minWidth: 0, paddingRight: 16 }}>
+              <div style={{ fontSize: 13, color: "var(--text-hi)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {s.query}
+              </div>
+              {s.error_msg && (
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--red)", marginTop: 2 }}>
+                  ✕ {s.error_msg}
+                </div>
+              )}
+            </div>
+
+            <StatusCell status={s.status} />
+
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)" }}>
+              {fmtDate(s.timestamp)}
+            </span>
+
+            {/* Duration, Tokens, Sources, Cost, Agents — not in SessionSummary, render — */}
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-hi)", fontVariantNumeric: "tabular-nums" }}>—</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)", textAlign: "right" }}>—</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)", textAlign: "right" }}>—</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-md)", textAlign: "right" }}>—</span>
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)" }}>—</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Footer / pagination */}
+      <div style={{
+        padding: "10px 32px", borderTop: "1px solid var(--border)", background: "var(--surface)",
+        display: "flex", alignItems: "center",
+        fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)",
+        letterSpacing: "0.12em", textTransform: "uppercase",
+      }}>
+        <span>SHOWING 1–{filtered.length} OF {sessions.length}</span>
+        <div style={{ marginLeft: "auto", display: "flex", gap: 14 }}>
+          <span>← PREV</span>
+          <span style={{ color: "var(--text-hi)" }}>1</span>
+          <span style={{ color: "var(--amber)" }}>NEXT →</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/components/buzz/Btn.tsx
+++ b/web/components/buzz/Btn.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { ButtonHTMLAttributes } from "react";
+
+interface BtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  primary?: boolean;
+  mini?: boolean;
+}
+
+export function Btn({ children, primary = false, mini = false, disabled, onClick, ...rest }: BtnProps) {
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      {...rest}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        fontWeight: 600,
+        padding: mini ? "4px 8px" : "8px 14px",
+        background: primary ? "var(--amber)" : "transparent",
+        color: primary ? "#0a0d14" : "var(--text-hi)",
+        border: primary ? "1px solid var(--amber)" : "1px solid var(--border)",
+        borderRadius: 2,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        transition: "background 0.15s",
+        ...rest.style,
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/components/buzz/KV.tsx
+++ b/web/components/buzz/KV.tsx
@@ -1,0 +1,33 @@
+interface KVProps {
+  k: string;
+  v: string | number;
+  mono?: boolean;
+}
+
+export function KV({ k, v, mono = true }: KVProps) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+          color: "var(--text-lo)",
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+        }}
+      >
+        {k}
+      </span>
+      <span
+        style={{
+          fontFamily: mono ? "var(--font-mono)" : "var(--font-sans)",
+          fontSize: 12,
+          color: "var(--text-hi)",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {v}
+      </span>
+    </div>
+  );
+}

--- a/web/components/buzz/SectionLabel.tsx
+++ b/web/components/buzz/SectionLabel.tsx
@@ -1,0 +1,24 @@
+interface SectionLabelProps {
+  children: React.ReactNode;
+  accent?: string;
+}
+
+export function SectionLabel({ children, accent = "var(--amber)" }: SectionLabelProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.18em",
+        textTransform: "uppercase",
+        color: "var(--text-md)",
+      }}
+    >
+      <span style={{ width: 4, height: 4, background: accent, display: "inline-block" }} />
+      {children}
+    </div>
+  );
+}

--- a/web/components/buzz/StatusChip.tsx
+++ b/web/components/buzz/StatusChip.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { StatusDot } from "./StatusDot";
+
+interface StatusChipProps {
+  status: string;
+  label?: string;
+}
+
+const CHIP_COLORS: Record<string, string> = {
+  running:  "var(--cyan)",
+  complete: "var(--green)",
+  error:    "var(--red)",
+  queued:   "var(--text-md)",
+  paused:   "var(--amber)",
+  live:     "var(--amber)",
+};
+
+export function StatusChip({ status, label }: StatusChipProps) {
+  const c = CHIP_COLORS[status] ?? CHIP_COLORS.queued;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontFamily: "var(--font-mono)",
+        fontSize: 10,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        padding: "3px 7px",
+        border: `1px solid ${c}40`,
+        background: `${c}12`,
+        color: c,
+        borderRadius: 2,
+      }}
+    >
+      <StatusDot status={status} pulse={status === "running"} />
+      {label ?? status}
+    </span>
+  );
+}

--- a/web/components/buzz/StatusDot.tsx
+++ b/web/components/buzz/StatusDot.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+interface StatusDotProps {
+  status: string;
+  size?: number;
+  pulse?: boolean;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  running:  "var(--cyan)",
+  complete: "var(--green)",
+  error:    "var(--red)",
+  queued:   "var(--text-lo)",
+  paused:   "var(--amber)",
+  live:     "var(--amber)",
+  idle:     "var(--text-lo)",
+};
+
+export function StatusDot({ status, size = 6, pulse = false }: StatusDotProps) {
+  const color = STATUS_COLORS[status] ?? "var(--text-lo)";
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        background: color,
+        borderRadius: 1,
+        flexShrink: 0,
+        boxShadow: pulse ? `0 0 8px ${color}` : undefined,
+        animation: pulse ? "buzz-pulse 1.8s ease-in-out infinite" : undefined,
+      }}
+    />
+  );
+}

--- a/web/components/buzz/SwarmGraph.tsx
+++ b/web/components/buzz/SwarmGraph.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface NodeState {
+  id: string;
+  status?: "running" | "idle" | "complete" | "error";
+}
+
+interface SwarmGraphProps {
+  width?: number;
+  height?: number;
+  nodeStates?: NodeState[];
+  animate?: boolean;
+}
+
+const NODE_DEFS = [
+  { id: "lead",     label: "LEAD",     role: "Orchestrator",  angle: -Math.PI / 2, color: "var(--amber)"  },
+  { id: "market",   label: "MARKET",   role: "Regulatory",    angle: 0,            color: "var(--cyan)"   },
+  { id: "analyst",  label: "ANALYST",  role: "Market sizing", angle: Math.PI / 2,  color: "var(--violet)" },
+  { id: "reporter", label: "REPORTER", role: "Synthesis",     angle: Math.PI,      color: "var(--green)"  },
+];
+
+const EDGES = [
+  { from: 0, to: 1 },
+  { from: 0, to: 2 },
+  { from: 0, to: 3 },
+  { from: 1, to: 2 },
+  { from: 2, to: 3 },
+];
+
+export function SwarmGraph({ width = 520, height = 360, animate = true }: SwarmGraphProps) {
+  const cx = width / 2;
+  const cy = height / 2;
+  const R = Math.min(width, height) * 0.32;
+
+  const nodes = NODE_DEFS.map(n => ({
+    ...n,
+    x: cx + Math.cos(n.angle) * R,
+    y: cy + Math.sin(n.angle) * R,
+  }));
+
+  const packetRefsOuter = useRef<(SVGCircleElement | null)[]>([]);
+  const packetRefsInner = useRef<(SVGCircleElement | null)[]>([]);
+  const animateRef = useRef(animate);
+  animateRef.current = animate;
+
+  useEffect(() => {
+    if (!animate) return;
+
+    let rafId: number;
+    let tick = 0;
+
+    const loop = () => {
+      tick = (tick + 1) % 600;
+
+      EDGES.forEach((e, i) => {
+        const phase = (tick / 90 + i * 0.27) % 1;
+        const a = nodes[e.from];
+        const b = nodes[e.to];
+        const px = a.x + (b.x - a.x) * phase;
+        const py = a.y + (b.y - a.y) * phase;
+
+        const outer = packetRefsOuter.current[i];
+        const inner = packetRefsInner.current[i];
+        if (outer) {
+          outer.setAttribute("cx", String(px));
+          outer.setAttribute("cy", String(py));
+        }
+        if (inner) {
+          inner.setAttribute("cx", String(px));
+          inner.setAttribute("cy", String(py));
+        }
+      });
+
+      rafId = requestAnimationFrame(loop);
+    };
+
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animate]);
+
+  return (
+    <div style={{ position: "relative", width, height }}>
+      <svg width={width} height={height} style={{ position: "absolute", inset: 0 }}>
+        <defs>
+          <pattern id="sg-grid" width="32" height="32" patternUnits="userSpaceOnUse">
+            <path d="M 32 0 L 0 0 0 32" fill="none" stroke="var(--border)" strokeOpacity="0.4" strokeWidth="0.5" />
+          </pattern>
+          <radialGradient id="sg-glow" cx="0.5" cy="0.5">
+            <stop offset="0" stopColor="var(--amber)" stopOpacity="0.4" />
+            <stop offset="1" stopColor="var(--amber)" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        {/* Grid background */}
+        <rect width={width} height={height} fill="url(#sg-grid)" />
+
+        {/* Corner crosshairs */}
+        {([[8, 8], [width - 8, 8], [8, height - 8], [width - 8, height - 8]] as [number, number][]).map(([x, y], i) => (
+          <g key={i} stroke="var(--text-lo)" strokeOpacity="0.4">
+            <line x1={x - 4} x2={x + 4} y1={y} y2={y} strokeWidth="0.6" />
+            <line x1={x} x2={x} y1={y - 4} y2={y + 4} strokeWidth="0.6" />
+          </g>
+        ))}
+
+        {/* Hub glow */}
+        <circle cx={cx} cy={cy} r={60} fill="url(#sg-glow)" />
+
+        {/* Edges */}
+        {EDGES.map((e, i) => (
+          <line
+            key={i}
+            x1={nodes[e.from].x} y1={nodes[e.from].y}
+            x2={nodes[e.to].x}   y2={nodes[e.to].y}
+            stroke="var(--text-lo)" strokeOpacity="0.35"
+            strokeWidth="0.8" strokeDasharray="3 3"
+          />
+        ))}
+
+        {/* Animated packets — positions updated imperatively via refs */}
+        {animate && EDGES.map((_, i) => (
+          <g key={i}>
+            <circle
+              ref={el => { packetRefsOuter.current[i] = el; }}
+              cx={nodes[EDGES[i].from].x} cy={nodes[EDGES[i].from].y}
+              r="6" fill="var(--amber)" opacity="0.25"
+            />
+            <circle
+              ref={el => { packetRefsInner.current[i] = el; }}
+              cx={nodes[EDGES[i].from].x} cy={nodes[EDGES[i].from].y}
+              r="3" fill="var(--amber)"
+            />
+          </g>
+        ))}
+
+        {/* Hub */}
+        <circle cx={cx} cy={cy} r="22" fill="var(--bg)" stroke="var(--amber)" strokeWidth="1" />
+        <circle cx={cx} cy={cy} r="6" fill="var(--amber)" />
+        <text x={cx} y={cy + 38} textAnchor="middle" fontFamily="var(--font-mono)" fontSize="9" fill="var(--text-lo)" letterSpacing="0.18em">SWARM</text>
+
+        {/* Nodes */}
+        {nodes.map(n => (
+          <g key={n.id}>
+            <circle cx={n.x} cy={n.y} r="18" fill="var(--surface)" stroke={n.color} strokeWidth="1" />
+            <circle cx={n.x} cy={n.y} r="4" fill={n.color}>
+              <animate attributeName="opacity" values="0.5;1;0.5" dur="1.4s" repeatCount="indefinite" />
+            </circle>
+            <text x={n.x} y={n.y + 32} textAnchor="middle" fontFamily="var(--font-mono)" fontSize="9"
+                  fill={n.color} letterSpacing="0.18em" fontWeight="600">{n.label}</text>
+            <text x={n.x} y={n.y + 44} textAnchor="middle" fontFamily="var(--font-mono)" fontSize="8.5"
+                  fill="var(--text-lo)">{n.role}</text>
+          </g>
+        ))}
+      </svg>
+
+      <div style={{ position: "absolute", top: 8, left: 12, fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)", letterSpacing: "0.18em" }}>
+        SWARM · LIVE
+      </div>
+      <div style={{ position: "absolute", top: 8, right: 12, fontFamily: "var(--font-mono)", fontSize: 9, color: "var(--text-lo)", letterSpacing: "0.18em" }}>
+        4 AGENTS · 5 EDGES
+      </div>
+    </div>
+  );
+}

--- a/web/components/buzz/TopNav.tsx
+++ b/web/components/buzz/TopNav.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+
+const TICKER_ITEMS = [
+  [{ sym: "GLP-1", val: "+$130B", c: "var(--green)" }, { sym: "CAR-T", val: "+12.4%", c: "var(--green)" }, { sym: "FDA", val: "47 IND", c: "var(--text-md)" }],
+  [{ sym: "ADC", val: "+18.2%", c: "var(--green)" }, { sym: "AAV", val: "−2.1%", c: "var(--red)" }, { sym: "NICE", val: "3 TAs", c: "var(--text-md)" }],
+  [{ sym: "OBES", val: "+22.8%", c: "var(--green)" }, { sym: "GENE", val: "+3.2%", c: "var(--green)" }, { sym: "EMA", val: "12 ATMP", c: "var(--text-md)" }],
+];
+
+const NAV_LINKS = [
+  { id: "research", label: "Research", href: "/" },
+  { id: "sessions", label: "Sessions", href: "/sessions" },
+  { id: "library",  label: "Library",  href: "/" },
+  { id: "models",   label: "Models",   href: "/" },
+];
+
+function BuzzLogo() {
+  return (
+    <div style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+      <svg width={18} height={18} viewBox="0 0 20 20" fill="none">
+        <circle cx="10" cy="10" r="2.2" fill="var(--amber)" />
+        <circle cx="10" cy="10" r="5" stroke="var(--amber)" strokeOpacity="0.6" strokeWidth="1" fill="none" />
+        <circle cx="10" cy="10" r="8.4" stroke="var(--amber)" strokeOpacity="0.25" strokeWidth="1" fill="none" />
+        <circle cx="10" cy="1.8" r="1.1" fill="var(--amber)" />
+        <circle cx="17.6" cy="13.8" r="1.1" fill="var(--amber)" opacity="0.7" />
+        <circle cx="2.4" cy="13.8" r="1.1" fill="var(--amber)" opacity="0.4" />
+      </svg>
+      <span style={{
+        fontFamily: "var(--font-mono)", fontSize: 11, letterSpacing: "0.18em",
+        fontWeight: 600, color: "var(--text-hi)", textTransform: "uppercase",
+      }}>
+        BUZZ<span style={{ color: "var(--amber)" }}>·</span>HC
+      </span>
+    </div>
+  );
+}
+
+function Ticker() {
+  const [t, setT] = useState(0);
+  useEffect(() => {
+    const i = setInterval(() => setT(x => x + 1), 4000);
+    return () => clearInterval(i);
+  }, []);
+  const cur = TICKER_ITEMS[t % TICKER_ITEMS.length];
+  return (
+    <div style={{
+      display: "flex", gap: 12, padding: "3px 8px",
+      border: "1px solid var(--border)", borderRadius: 2, background: "var(--surface)",
+    }}>
+      {cur.map(it => (
+        <div key={it.sym} style={{ display: "flex", gap: 5, alignItems: "center", fontFamily: "var(--font-mono)", fontSize: 10 }}>
+          <span style={{ color: "var(--text-lo)" }}>{it.sym}</span>
+          <span style={{ color: it.c }}>{it.val}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function resolveActive(pathname: string): string {
+  if (pathname === "/sessions") return "sessions";
+  if (pathname.startsWith("/query") || pathname.startsWith("/run")) return "research";
+  return "research";
+}
+
+export function TopNav() {
+  const pathname = usePathname();
+  const active = resolveActive(pathname);
+
+  return (
+    <header style={{
+      height: 44,
+      borderBottom: "1px solid var(--border)",
+      display: "flex", alignItems: "center",
+      padding: "0 16px", background: "var(--bg)",
+      gap: 24, flexShrink: 0, position: "sticky", top: 0, zIndex: 10,
+    }}>
+      <Link href="/"><BuzzLogo /></Link>
+      <div style={{ height: 16, width: 1, background: "var(--border)" }} />
+      <nav style={{ display: "flex", gap: 2, flex: 1 }}>
+        {NAV_LINKS.map(l => (
+          <Link
+            key={l.id}
+            href={l.href}
+            style={{
+              fontFamily: "var(--font-mono)", fontSize: 11, letterSpacing: "0.12em",
+              textTransform: "uppercase", padding: "6px 10px",
+              color: l.id === active ? "var(--text-hi)" : "var(--text-lo)",
+              borderBottom: l.id === active ? "2px solid var(--amber)" : "2px solid transparent",
+              marginBottom: -1,
+              textDecoration: "none",
+            }}
+          >
+            {l.label}
+          </Link>
+        ))}
+      </nav>
+      <Ticker />
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-lo)", letterSpacing: "0.08em" }}>Search</span>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, padding: "2px 5px", border: "1px solid var(--border)", borderRadius: 2, color: "var(--text-md)" }}>⌘K</span>
+      </div>
+      <div style={{
+        width: 22, height: 22, borderRadius: 11,
+        background: "var(--surface-2)", border: "1px solid var(--border)",
+        fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-md)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+      }}>JS</div>
+    </header>
+  );
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -36,7 +36,7 @@ export interface UsageStats {
   response_tokens: number;
 }
 
-export type SessionStatus = "running" | "complete" | "error";
+export type SessionStatus = "running" | "complete" | "error" | "queued" | "paused";
 
 export interface SessionSummary {
   session_id: string;


### PR DESCRIPTION
## Summary

- Replaced the light bento-grid UI with a full dark Bloomberg-terminal aesthetic across the entire frontend
- Added 8 new `buzz` atom components (`StatusDot`, `StatusChip`, `SectionLabel`, `Btn`, `KV`, `TopNav`, `SwarmGraph`) as the foundation for the new design system
- Introduced a dedicated `/query` route that accepts a question, starts a run, and navigates directly to the live run view — eliminating extra clicks
- Overhauled the sessions page with a dense 9-column table with status filter chips and smart row routing

## Details

- `globals.css`: full Bloomberg OKLCH dark palette with all 5 status token sets; `--radius: 0.125rem`
- `layout.tsx`: IBM Plex Sans + JetBrains Mono fonts; `<html className="dark">` server-side (no FOUC)
- `page.tsx`: 3-zone landing — status strip, hero with animated SwarmGraph, feature strip
- `sessions/page.tsx`: dense table, client-side status counts, row click routes `complete → /report/[id]`, others → `/run/[id]`
- `types.ts`: `SessionStatus` extended with `"queued" | "paused"`

## Test plan

- [ ] Start the dev server (`cd web && pnpm dev`) and verify the landing page renders with dark theme and animated SwarmGraph
- [ ] Confirm no FOUC on hard reload — `<html className="dark">` is set server-side
- [ ] Navigate to `/query`, enter a question, submit — verify run starts and redirects to `/run/{id}`
- [ ] Confirm `Cmd/Ctrl+Enter` submits the query form
- [ ] Open `/sessions` — verify dense table renders, status filter chips update counts, row clicks route correctly
- [ ] Check that sparse fields render `—` and `queued`/`paused` statuses display without errors
- [ ] Run `pnpm build` in `web/` — no TypeScript or build errors
- [ ] CI passes (`python-tests` + `nextjs-build`)

---

**Scope:** buzz_hc_frontend_redesign-01
**Iteration:** iteration_01
**Build:** 2
**Issue:** #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)